### PR TITLE
fill rectangle

### DIFF
--- a/draw_forest.gd
+++ b/draw_forest.gd
@@ -1,16 +1,24 @@
 extends TileMapLayer
 
-func _drawRectangle(width, height, starting_x, starting_y) -> void:
-	var fill_coords = Vector2i(width, height)
-	var starting_coords = Vector2i(starting_x, starting_y)
+func _fillRectangle(x1, y1, x2, y2) -> void: 
+	"""
+		fills from top left corner (x1, y1) to bottom right corner (x2, y2) inclusive
+	"""
+	
 	var atlas_coords = Vector2i(1, 1)
-	self.set_cell(fill_coords, 0, atlas_coords)
-	self.set_cell(starting_coords, 0, atlas_coords)
+	for x in range(x1, x2):
+		for y in range(y1, y2):
+			var fill_coords = Vector2i(x, y)
+			self.set_cell(fill_coords, 0, atlas_coords)
+
+	# var starting_coords = Vector2i(starting_x, starting_y)
+	# self.set_cell(fill_coords, 0, atlas_coords)
+	# self.set_cell(starting_coords, 0, atlas_coords)
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	_drawRectangle(900, 2000, 0, 0)
+	_fillRectangle(0, 0, 56, 125)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/draw_forest.gd
+++ b/draw_forest.gd
@@ -11,10 +11,6 @@ func _fillRectangle(x1, y1, x2, y2) -> void:
 			var fill_coords = Vector2i(x, y)
 			self.set_cell(fill_coords, 0, atlas_coords)
 
-	# var starting_coords = Vector2i(starting_x, starting_y)
-	# self.set_cell(fill_coords, 0, atlas_coords)
-	# self.set_cell(starting_coords, 0, atlas_coords)
-
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/forest.tscn
+++ b/forest.tscn
@@ -81,7 +81,7 @@ texture = ExtResource("1_stcry")
 [sub_resource type="TileSet" id="TileSet_vmuxp"]
 sources/0 = SubResource("TileSetAtlasSource_mvm06")
 
-[node name="Node2D" type="Node2D"]
+[node name="Forest" type="Node2D"]
 
 [node name="TileMapLayer" type="TileMapLayer" parent="."]
 tile_set = SubResource("TileSet_vmuxp")

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="bird-game-2025"
-run/main_scene="uid://bhptmanbbjpca"
+run/main_scene="uid://lbpw7kq2pqqo"
 config/features=PackedStringArray("4.4", "Mobile")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
imported [Sprout Lands](https://cupnooble.itch.io/sprout-lands-asset-pack) tileset
created forest scene (forest.tscn)
added a script (draw_forest.gd) that paints a rectangle using the tile set

![Screenshot 2025-06-02 at 4 47 53 PM](https://github.com/user-attachments/assets/02522313-1602-4fa0-b2c4-3b44663c22b9)
