### PR TITLE
Propose new viewport resolution and window resolution override

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,6 @@ config_version=5
 [application]
 
 config/name="bird-game-2025"
-config/tags=PackedStringArray("rc")
 run/main_scene="uid://lbpw7kq2pqqo"
 config/features=PackedStringArray("4.4", "Mobile")
 config/icon="res://icon.svg"


### PR DESCRIPTION
Resolves #5 

## Information

**I propose we set our viewport resolution (which acts as our native resolution) as 270x480.** Multiplying 4 on width and height gives us a potentially desired 1080x1920. Originally, the viewport resolution was set at 1080x2400 which should actually be our window width/height override.

## Motivation

The motivation for this is that pixel art is best done on a smaller viewport resolution so that the tiles are viewable in full detail! A height of 480px, for example, means we can fit 480px / 16px = 30 tiles. The window width/height override is where we can set the project dimensions based on the user device, and this can be accomplished programmatically if we choose to do so. 

## Procedure

![image](https://github.com/user-attachments/assets/12605793-0045-488f-aeb4-005c44c17b3f)

I've modified the `Viewport Width` and `Viewport Height` under `Project > Project Settings` to adhere to the aforementioned resolutions. I have done the same to `Window Width Override` and `Window Height Override`.

## Closing Notes

N/A